### PR TITLE
 Set state in all paths through findContact() and return immediately in all cases

### DIFF
--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -200,25 +200,27 @@ class CRM_CsvImportHelper {
         elseif (count($record['resolution']) > 1) {
           // More than one contact matched.
           // quick scan to see if there's only one that matches first name
-          $m = array_filter($record['resolution'], function ($_, $contact_id) use ($contacts, $record) {
-            $contact = $contacts[$contact_id];
+          $m = array_filter($record['resolution'], function ($_) use ($contacts, $record) {
+            $contact = $contacts['values'][$_['contact_id']];
             return ($contact['first_name'] && $record['fname'] && $contact['first_name'] == $record['fname']);
           });
           if (count($m) == 1) {
             // Only one of these matches on (email and) first name, use that.
-            $record['contact_id'] = (string) key($m);
+            $record['resolution'] = $m;
+            $record['contact_id'] = (string) reset($m)['contact_id'];
             $record['state'] = 'found';
             return;
           }
 
           // quick scan to see if there's only one that matches last name
-          $m = array_filter($record['resolution'], function ($_, $contact_id) use ($contacts, $record) {
-            $contact = $contacts[$contact_id];
+          $m = array_filter($record['resolution'], function ($_) use ($contacts, $record) {
+            $contact = $contacts['values'][$_['contact_id']];
             return ($contact['last_name'] && $record['lname'] && $contact['last_name'] == $record['lname']);
           });
           if (count($m) == 1) {
             // Only one of these matches on (email and) last name, use that.
-            $record['contact_id'] = (string) key($m);
+            $record['resolution'] = $m;
+            $record['contact_id'] = (string) reset($m)['contact_id'];
             $record['state'] = 'found';
             return;
           }

--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -226,7 +226,7 @@ class CRM_CsvImportHelper {
           }
 
           // Don't look wider than matched emails.
-          $record['state'] = 'multiple';
+          $record['state'] = '';
           $record['contact_id'] = 0;
           return;
         }

--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -208,6 +208,7 @@ class CRM_CsvImportHelper {
             // Only one of these matches on (email and) first name, use that.
             $record['contact_id'] = (string) key($m);
             $record['state'] = 'found';
+            return;
           }
 
           // quick scan to see if there's only one that matches last name
@@ -219,9 +220,12 @@ class CRM_CsvImportHelper {
             // Only one of these matches on (email and) last name, use that.
             $record['contact_id'] = (string) key($m);
             $record['state'] = 'found';
+            return;
           }
 
           // Don't look wider than matched emails.
+          $record['state'] = 'multiple';
+          $record['contact_id'] = 0;
           return;
         }
       }
@@ -331,6 +335,7 @@ class CRM_CsvImportHelper {
       if ($result['count'] > 10) {
         $record['state'] = 'multiple';
         $record['contact_id'] = 0;
+        return;
       }
       elseif ($result['count'] > 0) {
         // could be any of these contacts

--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -482,7 +482,7 @@ class CRM_CsvImportHelper {
     $wheres = $wheres ? ('AND ' . implode(' AND ', $wheres)) : '';
 
     // Select every column except 'data'. Keep original input order (id)
-    // Nb. Fix ssue #2
+    // Nb. Fix issue #2
     // Certain MySQL engines (e.g. 5.7) don't allow selecting a field that is
     // not in a GROUP BY or aggregate function. So we have to use a subquery +
     // join to simulate FIRST() sort of thing. Of course this would be nicer if
@@ -605,9 +605,9 @@ class CRM_CsvImportHelper {
 
     // Select everything except 'data'.
     $sql = "
-      SELECT MIN(id) id, title, fname, lname, email FROM civicrm_csv_match_cache
+      SELECT MIN(id) id, fname, lname, email FROM civicrm_csv_match_cache
       WHERE contact_id = 0 AND state != 'header'
-      GROUP BY title, fname, lname, email
+      GROUP BY fname, lname, email
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);
 
@@ -624,14 +624,16 @@ class CRM_CsvImportHelper {
 
   }
   /**
-   * Rescan all un-selected contacts.
+   * Create new contacts (Individuals) where the state is 'impossible' meaning
+   * either no matches exist or the user has said explicitly that it is a new
+   * contact.
    */
   public static function createMissingContacts() {
 
     $sql = "
-      SELECT MIN(id) id, title, fname, lname, email FROM civicrm_csv_match_cache
+      SELECT MIN(id) id, fname, lname, email FROM civicrm_csv_match_cache
       WHERE contact_id = 0 AND state = 'impossible'
-      GROUP BY title, fname, lname, email
+      GROUP BY fname, lname, email
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);
 

--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -631,7 +631,7 @@ class CRM_CsvImportHelper {
     $sql = "
       SELECT MIN(id) id, title, fname, lname, email FROM civicrm_csv_match_cache
       WHERE contact_id = 0 AND state = 'impossible'
-      GROUP BY fname, lname, email
+      GROUP BY title, fname, lname, email
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);
 

--- a/CRM/CsvImportHelper.php
+++ b/CRM/CsvImportHelper.php
@@ -607,7 +607,7 @@ class CRM_CsvImportHelper {
     $sql = "
       SELECT MIN(id) id, title, fname, lname, email FROM civicrm_csv_match_cache
       WHERE contact_id = 0 AND state != 'header'
-      GROUP BY fname, lname, email
+      GROUP BY title, fname, lname, email
     ";
     $dao = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
When I press Re-check and there is a row in the CSV which matches 2 or more contacts on email address, a fatal error is raised saying " is not of type String".

Looking at the code it turns out that $record['state'] is not being set in this case. I've made 3 changes related to this ...

1. Reviewing the code of findContact(), it appears the pattern is that once a decision has been made, $record['state'] and $record['contact_id'] are set and we return. I added that logic in this case and the fatal error goes away.

2. Reviewing the code of findContact(), it appears the pattern found at point 1 is not followed in the case when more that 10 matching contacts are found. I adding a return statement, so this case doesn't fall through and revert to the 'impossible' case.

3. After matching on email address, the code looks at first name and then last name in an attempt to get a single item, which is then considered as the 'found' record. However the callback used will only ever return an empty result.

Caveat: when I load the CSV file the row for "email address matches multiple contacts" is grey and in the database its state is '' (the empty string). With my change I preserve this behaviour. @artfulrobot you may want to change '' to 'multiple' to match the other cases in findContact(). 